### PR TITLE
Update README for Track Event endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ event_details= {
 
 ic.track_event(email="abe.lincoln@usa.gov",
 				event_name="app_login",
-				dataFields=event_details,
+				data_fields=event_details,
 				campaign_id=215,
 				template_id= 1000)
 ```


### PR DESCRIPTION
from [client.py](https://github.com/carter-j-h/iterable-python-wrapper/blob/10d5db034ddfdfc3333efeee07fc9228b6a998c4/iterablepythonwrapper/client.py#L363), the track_events method doesn't use camel case.